### PR TITLE
[FEAT] Changer la couleur de la bordure d'un élément en rouge au hover du bouton supprimer

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -28,3 +28,17 @@ h1 {
 .modulix-editor-render__input--has-error {
   border: 1px solid red;
 }
+
+.card-body:has(
+  > .btn-group > .json-editor-btn-delete:hover,
+  ~ .btn-group > .json-editor-btn-delete:hover
+) {
+  border-color: #ff4d4f;
+  transition: border ease-in 0.2s;
+}
+
+.json-editor-btn-delete:hover {
+  background: #ff4d4f;
+  border-color: #ff4d4f;
+  transition: all ease-in 0.2s;
+}


### PR DESCRIPTION
## :unicorn: Problème
Il peut être difficile de savoir quel élément on va supprimer. En effet, le bouton `Delete` n'est pas forcément dans la même bordure que son élément correspondant.

## :robot: Proposition
Changer en rouge la couleur de la bordure de l'élément correspondant au hover du bouton `Delete`

## :rainbow: Remarques
On change aussi la couleur du bouton `Delete` pour signaler que c'est potentiellement dangereux.

## :100: Pour tester
Se mettre en hover d'un bouton supprimer et vérifier que le bon élément est entouré en rouge.
