### PR TITLE
Ajouter un lien vers la page de preview des modules (PIX-14095)

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
       </div>
 
       <div class="modulix-editor__render">
+        <a href="https://app.pix.fr/modules/preview" target="_blank" class="modulix-editor-render__external-link">Preview Modulix</a>
         <h2>JSON à copier/coller</h2>
         <textarea
           id="json_output"

--- a/styles.css
+++ b/styles.css
@@ -18,6 +18,10 @@ h1 {
   height: 80vh;
 }
 
+.modulix-editor-render__external-link {
+  color: black;
+}
+
 .modulix-editor-render__input {
   height: 100%;
   width: 100%;


### PR DESCRIPTION
## :unicorn: Problème
Nous aimerions pouvoir nous rendre facilement vers la page de prévisualisation de pix app.

## :robot: Proposition
Dans l'index, ajouter un lien vers la page de prévisualisation.

## :rainbow: Remarques
Le rendu n'est pas super actuellement, à discuter en équipe (voir ci-dessous)
![image](https://github.com/user-attachments/assets/e0fb5873-4b50-4a64-a414-cb1c78fb355b)


## :100: Pour tester

1. Se rendre sur [Modulix Editor](https://1024pix.github.io/modulix-editor/)
2. Constater que le lien vers la page de preview est bien présent à la bonne place
3. Constater qu'il mène bien vers l'URL "https://app.pix.fr/modules/preview" dans un nouvel onglet.
