### PR TITLE
[FEATURE] Sauvegarder automatiquement les modifications (PIX-14569)

### DIFF
--- a/LocalBackup.js
+++ b/LocalBackup.js
@@ -1,0 +1,17 @@
+export default class LocalBackup {
+  static localStorageKey = 'modulix-schema';
+
+  static save(schema) {
+    const schemaAsString = JSON.stringify(schema);
+    window.localStorage.setItem(this.localStorageKey, schemaAsString);
+  }
+
+  static load() {
+    const schemaAsString = window.localStorage.getItem(this.localStorageKey);
+    try {
+      return JSON.parse(schemaAsString);
+    } catch {
+      window.localStorage.removeItem(this.localStorageKey);
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -34,14 +34,27 @@
     <h1>Modulix Editor</h1>
 
     <main class="modulix-editor">
+
       <div>
+
+
+        <div class="mb-2">
+          <a class="btn btn-outline-info" href="https://app.pix.fr/modules/preview" target="_blank">
+            <span class="fa fa-eye"></span>
+            Prévisualiser
+          </a>
+          <button class="btn btn-outline-danger" id="reset-button">
+            <span class="fa fa-trash"></span>
+            Réinitialiser
+          </button>
+        </div>
         <h2>Contenu</h2>
         <div id="editor_holder"></div>
       </div>
 
       <div class="modulix-editor__render">
-        <a href="https://app.pix.fr/modules/preview" target="_blank" class="modulix-editor-render__external-link">Preview Modulix</a>
         <h2>JSON à copier/coller</h2>
+
         <textarea
           id="json_output"
           class="modulix-editor-render__input"
@@ -83,6 +96,13 @@
         disable_properties: true,
         disable_array_reorder: true,
         form_name_root: 'Module',
+      });
+
+      const resetButton = document.querySelector('#reset-button');
+      resetButton.addEventListener('click', () => {
+        if (window.confirm('Voulez-vous vraiment réinitialiser le module ? Toutes les modifications seront perdues.')) {
+          editor.setValue({})
+        }
       });
 
       editor.on('change', () => {

--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@
     <script src="https://cdn.jsdelivr.net/npm/jodit@4.2.27/es2018/jodit.fat.min.js"></script>
     <script type="module">
       import { schema } from './modulix.json-schema.js';
+      import LocalBackup from './LocalBackup.js';
 
       const element = document.getElementById('editor_holder');
       const jsonOutput = document.getElementById('json_output');
@@ -90,6 +91,7 @@
         }
 
         displayJsonOutputError();
+        LocalBackup.save(editor.getValue());
       });
 
       jsonOutput.addEventListener('focusout', () => {
@@ -113,6 +115,11 @@
           jsonOutput.classList.add('modulix-editor-render__input--has-error');
         }
       }
+
+      editor.on('ready', () => {
+         const schema = LocalBackup.load();
+         editor.setValue(schema);
+      });
     </script>
   </body>
 </html>


### PR DESCRIPTION
## :unicorn: Problème

Si l'utilisateur ferme l'onglet ou recharge la page de Modulix Editor par inadvertance, le contenu du champ d'édition sera perdu.

## :robot: Proposition

- Sauvegarder le contenu du champ d'édition dans le local storage
- Ajouter un bouton pour réintialiser le contenu du champ

## :rainbow: Remarques

RAS

## :100: Pour tester

- Modifier le contenu du module
- Fermer puis réouvrir l'onglet et constater que le contenu n'est pas réinitialisé
- Recharger la page et constater que le contenu n'est pas réinitialisé
- Cliquer sur le bouton "Réinitialiser" et constater que le contenu est réinitialisé