### PR TITLE
[FEATURE] Supporter l'élément expand (PIX-15775)

### DIFF
--- a/modulix.json-schema.js
+++ b/modulix.json-schema.js
@@ -222,6 +222,36 @@ export const schema = {
                             "type": {
                               "type": "string",
                               "enum": [
+                                "expand"
+                              ]
+                            },
+                            "title": {
+                              "type": "string"
+                            },
+                            "content": {
+                              "type": "string",
+                              "format": "jodit"
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "type",
+                            "title",
+                            "content"
+                          ],
+                          "additionalProperties": false,
+                          "title": "expand"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
                                 "flashcards"
                               ]
                             },
@@ -878,6 +908,36 @@ export const schema = {
                                   ],
                                   "additionalProperties": false,
                                   "title": "download"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "expand"
+                                      ]
+                                    },
+                                    "title": {
+                                      "type": "string"
+                                    },
+                                    "content": {
+                                      "type": "string",
+                                      "format": "jodit"
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "type",
+                                    "title",
+                                    "content"
+                                  ],
+                                  "additionalProperties": false,
+                                  "title": "expand"
                                 },
                                 {
                                   "type": "object",


### PR DESCRIPTION
## :christmas_tree: Problème

L'élément Expand a été ajouté à Modulix, mais il n'est pas supporté par Modulix Editor.

## :gift: Proposition

Ajouter Expand aux éléments supportés par Modulix Editor

## :socks: Remarques

RAS

## :santa: Pour tester

1. Ajouter un élément de type Expand à un grain
2. Renseigner un titre et un contenu
3. Cliquer sur **Afficher le JSON**
4. Constater l'ajout de l'élément Expand avec les bonnes propriétés au code JSON

