### PR TITLE
[FEATURE] Supprimer les balises ajoutées automatiquement dans un WYSIWYG

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,8 +53,8 @@
             Réinitialiser
           </button>
           <button class="btn btn-info" id="format-button">
-            <span class="fa fa-heart"></span>
-            Espaces insécables
+            <span class="fa fa-broom"></span>
+            Nettoyer
           </button>
         </div>
         <h2>Contenu</h2>
@@ -176,6 +176,7 @@
         );
         jsonValue = jsonValue.replaceAll(/ ([;?!])/g, ' $1');
         jsonValue = jsonValue.replaceAll(/(«) | ([»:])/g, '$1 $2');
+        jsonValue = jsonValue.replaceAll(/<p><br><\/p>(\\n)?/g, '');
 
         const output = JSON.parse(jsonValue);
         jsonOutput.value = JSON.stringify(output, null, 2);


### PR DESCRIPTION
## 🌸 Problème

Sur Jodit, le focus ainsi que le saut de ligne ajoute automatiquement les balises <p><br></p> comme précisé dans la [doc](https://xdsoft.net/jodit/docs/modules/plugins_enter.html) 


## 🌳 Proposition
Améliorer le bouton Espaces insécables pour supprimer ces balises générés. 

## 🐝 Remarques
- Il semble avoir un bug sur Jodit car la suppression du plugin Enter est censé gérer ce cas. Cela ne marche malheureusement pas même sur la page de test proposé sur le site de Jodit : https://xdsoft.net/jodit/play.html?disablePlugins=enter&currentTab=Plugins

## 🤧 Pour tester

1. Ajouter un grain avec un élément Text.
2. Appuyer plusieurs fois sur entrée dans le WYSIWYG. Constater que cela génère des balises `<p><br></p>`
3. Appuyer sur le bouton Nettoyer et constater que les balises sont supprimées 😄 
