### PR TITLE
[FEATURE] Permettre de créer des éléments de type QCUDeclarative (PIX-17685)

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,39 +31,36 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <h1>Modulix Editor</h1>
 
     <main class="modulix-editor">
       <div class="modulix-editor__editor">
-        <div class="mb-2">
-          <button class="btn btn-outline-info" id="preview-button">
-            <span class="fa fa-eye"></span>
-            Previsualiser
-          </button>
-          <button class="btn btn-outline-success" id="toggle-json-button">
+
+        <header class="d-flex flex-wrap gap-3">
+          <h1>Modulix Editor</h1>
+
+          <div class="mb-2 btn-group">
+            <button class="btn btn-secondary" id="preview-button" aria-label="Prévisualiser" data-tooltip="Prévisualiser">
+              <span class="fa fa-eye"></span>
+            </button>
+            <button class="btn btn-secondary" id="toggle-json-button" aria-label="Afficher le JSON" data-tooltip="Afficher le JSON"">
             <span class="fa fa-code"></span>
-            Afficher le JSON
-          </button>
-          <button class="btn btn-outline-warning" id="download-json-button">
-            <span class="fa fa-download"></span>
-            Télécharger le JSON
-          </button>
-          <button class="btn btn-outline-danger" id="reset-button">
-            <span class="fa fa-trash"></span>
-            Réinitialiser
-          </button>
-          <button class="btn btn-info" id="format-button">
-            <span class="fa fa-broom"></span>
-            Nettoyer
-          </button>
-        </div>
-        <h2>Contenu</h2>
+            </button>
+            <button class="btn btn-secondary" id="download-json-button" aria-label="Télécharger le JSON" data-tooltip="Télécharger le JSON">
+              <span class="fa fa-download"></span>
+            </button>
+            <button class="btn btn-secondary" id="reset-button" aria-label="Réinitialiser" data-tooltip="Réinitialiser">
+              <span class="fa fa-trash"></span>
+            </button>
+            <button class="btn btn-secondary" id="format-button" aria-label="Nettoyer" data-tooltip="Nettoyer">
+              <span class="fa fa-broom"></span>
+            </button>
+          </div>
+        </header>
+
         <div id="editor_holder"></div>
       </div>
 
       <div class="modulix-editor__render" id="json-output-pane">
-        <h2>JSON à copier/coller</h2>
-
         <textarea
           id="json_output"
           class="modulix-editor-render__input"
@@ -73,9 +70,13 @@
 
     <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@latest/dist/jsoneditor.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/jodit@4.2.27/es2018/jodit.fat.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js" integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO" crossorigin="anonymous"></script>
     <script type="module">
       import { schema } from './modulix.json-schema.js';
       import LocalBackup from './LocalBackup.js';
+
+      const tooltipTriggerList = document.querySelectorAll('[data-tooltip]');
+      [...tooltipTriggerList].map(el => new bootstrap.Tooltip(el, { placement: 'bottom', trigger: 'hover', title: el.dataset.tooltip }));
 
       const element = document.getElementById('editor_holder');
       const jsonOutput = document.getElementById('json_output');

--- a/modulix.json-schema.js
+++ b/modulix.json-schema.js
@@ -487,6 +487,74 @@ export const schema = {
                             "type": {
                               "type": "string",
                               "enum": [
+                                "qcu-declarative"
+                              ]
+                            },
+                            "instruction": {
+                              "type": "string",
+                              "format": "jodit"
+                            },
+                            "proposals": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "id": {
+                                    "type": "string",
+                                    "pattern": "^[0-9]+$"
+                                  },
+                                  "content": {
+                                    "type": "string",
+                                    "format": "jodit"
+                                  },
+                                  "feedback": {
+                                    "type": "object",
+                                    "properties": {
+                                      "state": {
+                                        "type": "string",
+                                        "format": "jodit"
+                                      },
+                                      "diagnosis": {
+                                        "type": "string",
+                                        "format": "jodit"
+                                      }
+                                    },
+                                    "required": [
+                                      "state",
+                                      "diagnosis"
+                                    ],
+                                    "additionalProperties": false
+                                  }
+                                },
+                                "required": [
+                                  "id",
+                                  "content",
+                                  "feedback"
+                                ],
+                                "additionalProperties": false,
+                                "title": "proposal"
+                              }
+                            }
+                          },
+                          "required": [
+                            "id",
+                            "type",
+                            "instruction",
+                            "proposals"
+                          ],
+                          "additionalProperties": false,
+                          "title": "qcu-declarative"
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "format": "uuid"
+                            },
+                            "type": {
+                              "type": "string",
+                              "enum": [
                                 "qcm"
                               ]
                             },
@@ -1156,6 +1224,74 @@ export const schema = {
                                   ],
                                   "additionalProperties": false,
                                   "title": "qcu"
+                                },
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "id": {
+                                      "type": "string",
+                                      "format": "uuid"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "qcu-declarative"
+                                      ]
+                                    },
+                                    "instruction": {
+                                      "type": "string",
+                                      "format": "jodit"
+                                    },
+                                    "proposals": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "id": {
+                                            "type": "string",
+                                            "pattern": "^[0-9]+$"
+                                          },
+                                          "content": {
+                                            "type": "string",
+                                            "format": "jodit"
+                                          },
+                                          "feedback": {
+                                            "type": "object",
+                                            "properties": {
+                                              "state": {
+                                                "type": "string",
+                                                "format": "jodit"
+                                              },
+                                              "diagnosis": {
+                                                "type": "string",
+                                                "format": "jodit"
+                                              }
+                                            },
+                                            "required": [
+                                              "state",
+                                              "diagnosis"
+                                            ],
+                                            "additionalProperties": false
+                                          }
+                                        },
+                                        "required": [
+                                          "id",
+                                          "content",
+                                          "feedback"
+                                        ],
+                                        "additionalProperties": false,
+                                        "title": "proposal"
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "id",
+                                    "type",
+                                    "instruction",
+                                    "proposals"
+                                  ],
+                                  "additionalProperties": false,
+                                  "title": "qcu-declarative"
                                 },
                                 {
                                   "type": "object",

--- a/styles.css
+++ b/styles.css
@@ -19,7 +19,7 @@ h1 {
   display: none;
   position: sticky;
   top: 0;
-  height: 80vh;
+  height: calc(100vh - 16px);
   width: 35%;
 }
 


### PR DESCRIPTION
## :egg: Problème

Il n'est pas possible de créer un élément QCUDeclarative à l'aide de Modulix Editor.

## :bowl_with_spoon: Proposition

Ajouter le nouvel élément au schéma JSON.

## :milk_glass: Remarques

Proposition d'allègement de l'interface au passage

## :butter: Pour tester

Constater qu'il est possible de créer un élément QCUDeclarative avec des proposals et des feedbacks.
