### PR TITLE
[FEATURE] Supprimer le tag "Points clés" de la liste (PIX-22247)

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,16 @@ function init(schema) {
     collapsed: true,
   };
 
+  schema.properties.sections.items.options = {
+    collapsed: true,
+  };
+
+  // remove 'key-points' in tag list enumerations
+  const tagNamesEnum = schema.properties.sections.items.properties.grains.items.properties.components.items.oneOf[0].properties.element
+    .oneOf.find(element => element.title === 'text').properties.tag.enum
+  const indexToRemove = tagNamesEnum.indexOf('key-points')
+  tagNamesEnum.splice(indexToRemove, 1);
+
   schema.properties.shortId.default = generateId();
   schema.properties.shortId.readonly = true;
 


### PR DESCRIPTION
## 🌱 Problème

Dans une modalité Text, on ne veut plus que le métier puisse sélectionner un tag de type "key-points".

## 🐣 Proposition

Modifier le schéma récupéré depuis l'api, pour enlever "key-points" de l'énumération des tags de text-element.

## 🌷 Remarques

- Peut-on mieux faire?

## 🐝 Pour tester

- En local, lancer et ouvrir modulix-editor
- Vérifier qu'on ne peut pas sélectionner "key-points" dans la liste des tag pour un text-element
