### PR TITLE
[TECH] Utiliser monaco editor comme nouvel éditeur JSON (PIX-22298)

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,10 +108,10 @@
             <span class="fa fa-copy me-1"></span> Copier
           </button>
         </div>
-        <textarea
+        <div
           id="json_output"
           class="modulix-editor-render__input"
-        ></textarea>
+        ></div>
       </div>
     </main>
 

--- a/index.js
+++ b/index.js
@@ -245,7 +245,6 @@ function init(schema) {
       monacoEditor.setValue(newJson);
     }
 
-    displayJsonOutputError(jsonOutput);
     LocalBackup.save(editor.getValue());
     const moduleContent = editor.getValue();
     sendDataForPreview(previewWindow, moduleContent);
@@ -258,8 +257,6 @@ function init(schema) {
     } catch (error) {
       console.error(error);
     }
-
-    displayJsonOutputError(jsonOutput);
   });
 
   editor.on('ready', () => {
@@ -282,17 +279,6 @@ function generateId() {
   const arr = new Uint8Array((8 || 40) / 2);
   window.crypto.getRandomValues(arr);
   return Array.from(arr, dec2hex).join('');
-}
-
-function displayJsonOutputError(jsonOutput) {
-  try {
-    JSON.parse(jsonOutput.value);
-    jsonOutput.classList.remove(
-      'modulix-editor-render__input--has-error',
-    );
-  } catch {
-    jsonOutput.classList.add('modulix-editor-render__input--has-error');
-  }
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -66,6 +66,8 @@ function init(schema) {
     scrollBeyondLastLine: false,
     fontSize: 13,
     fontFamily: "'SF Mono', 'Fira Code', 'Consolas', monospace",
+    wordWrap: 'wordWrapColumn',
+    wordWrapColumn: 60,
   });
 
   Jodit.defaultOptions.toolbarAdaptive = false;

--- a/index.js
+++ b/index.js
@@ -1,5 +1,14 @@
 import LocalBackup from './LocalBackup.js';
+import * as monaco from 'monaco-editor';
+import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
+import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';
 
+self.MonacoEnvironment = {
+  getWorker(_, label) {
+    if (label === 'json') return new jsonWorker();
+    return new editorWorker();
+  },
+};
 
 const schemaUrls = [
   'https://api.integration.pix.fr/api/module-schema/module-json-schema.json',
@@ -48,7 +57,16 @@ function init(schema) {
   );
 
   const element = document.getElementById('editor_holder');
-  const jsonOutput = document.getElementById('json_output');
+  const jsonOutputContainer = document.getElementById('json_output');
+  const monacoEditor = monaco.editor.create(jsonOutputContainer, {
+    language: 'json',
+    theme: 'vs',
+    automaticLayout: true,
+    minimap: { enabled: false },
+    scrollBeyondLastLine: false,
+    fontSize: 13,
+    fontFamily: "'SF Mono', 'Fira Code', 'Consolas', monospace",
+  });
 
   Jodit.defaultOptions.toolbarAdaptive = false;
   Jodit.defaultOptions.buttons =
@@ -140,7 +158,7 @@ function init(schema) {
 
   const copyJsonButton = document.querySelector('#copy-json-button');
   copyJsonButton.addEventListener('click', () => {
-    navigator.clipboard.writeText(jsonOutput.value).then(() => {
+    navigator.clipboard.writeText(monacoEditor.getValue()).then(() => {
       copyJsonButton.innerHTML = '<span class="fa fa-check me-1"></span> Copié !';
       setTimeout(() => {
         copyJsonButton.innerHTML = '<span class="fa fa-copy me-1"></span> Copier';
@@ -199,7 +217,7 @@ function init(schema) {
     jsonValue = jsonValue.replaceAll(/'/g, '’');
 
     const output = JSON.parse(jsonValue);
-    jsonOutput.value = JSON.stringify(output, null, 2);
+    monacoEditor.setValue(JSON.stringify(output, null, 2));
     editor.setValue(output);
   });
 
@@ -222,8 +240,9 @@ function init(schema) {
   });
 
   editor.on('change', () => {
-    if (JSON.stringify(editor.getValue(), null, 2) !== jsonOutput.value) {
-      jsonOutput.value = JSON.stringify(editor.getValue(), null, 2);
+    const newJson = JSON.stringify(editor.getValue(), null, 2);
+    if (newJson !== monacoEditor.getValue()) {
+      monacoEditor.setValue(newJson);
     }
 
     displayJsonOutputError(jsonOutput);
@@ -232,9 +251,9 @@ function init(schema) {
     sendDataForPreview(previewWindow, moduleContent);
   });
 
-  jsonOutput.addEventListener('focusout', () => {
+  monacoEditor.onDidBlurEditorText(() => {
     try {
-      const value = JSON.parse(jsonOutput.value);
+      const value = JSON.parse(monacoEditor.getValue());
       editor.setValue(value);
     } catch (error) {
       console.error(error);

--- a/index.js
+++ b/index.js
@@ -81,6 +81,11 @@ function init(schema) {
     fontFamily: "'SF Mono', 'Fira Code', 'Consolas', monospace",
     wordWrap: 'wordWrapColumn',
     wordWrapColumn: 60,
+    unicodeHighlight: {
+      ambiguousCharacters: false,
+      invisibleCharacters: false,
+      nonBasicASCII: false,
+    },
   });
 
   Jodit.defaultOptions.toolbarAdaptive = false;

--- a/index.js
+++ b/index.js
@@ -58,8 +58,21 @@ function init(schema) {
 
   const element = document.getElementById('editor_holder');
   const jsonOutputContainer = document.getElementById('json_output');
+
+  monaco.json.jsonDefaults.setDiagnosticsOptions({
+    validate: true,
+    schemas: [{ uri: 'inmemory://modulix/module-schema.json', fileMatch: ['module.json'], schema }],
+    schemaValidation: "error"
+  });
+
+  const model = monaco.editor.createModel(
+    '',
+    'json',
+    monaco.Uri.parse('inmemory://modulix/module.json'),
+  );
+
   const monacoEditor = monaco.editor.create(jsonOutputContainer, {
-    language: 'json',
+    model,
     theme: 'vs',
     automaticLayout: true,
     minimap: { enabled: false },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@1024pix/pix-ui": "^60.5.0"
+        "@1024pix/pix-ui": "^60.5.0",
+        "monaco-editor": "^0.55.1"
       },
       "devDependencies": {
         "prettier": "^3.6.2",
@@ -2490,6 +2491,13 @@
       "integrity": "sha512-MQ1AnmTLOncwEf9IVU+B2e4Hchrku5N67NkgcAHW0p3sdzPe0FNMANxEm6OJUzPniEQGkeT3OROLlCwZJLWFZA==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -4567,6 +4575,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
+      "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -8060,6 +8077,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/matcher-collection": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
@@ -8256,6 +8285,16 @@
       "license": "MIT",
       "engines": {
         "node": "20 || 22 || 24"
+      }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.55.1.tgz",
+      "integrity": "sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "vite": "^8.0.0"
   },
   "dependencies": {
-    "@1024pix/pix-ui": "^60.5.0"
+    "@1024pix/pix-ui": "^60.5.0",
+    "monaco-editor": "^0.55.1"
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -119,18 +119,7 @@ h1.modulix-editor__title {
   width: 100%;
   border: 1px solid var(--border);
   border-radius: 0 0 6px 6px;
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
-  font-size: 13px;
-  padding: 8px;
-  color: var(--text);
-  background: var(--surface);
-  resize: none;
-}
-
-.modulix-editor-render__input--has-error {
-  border-color: var(--error);
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(229, 62, 62, 0.15);
+  overflow: hidden;
 }
 
 


### PR DESCRIPTION
## 🌱 Problème

Actuellement, le champ contenant le JSON d'un module manque de colorations, indentation, numéro de lignes...
Cela n'incite pas à le modifier directement.

## 🐣 Proposition

Le panneau JSON utilise un simple `<textarea>` pour afficher et éditer le JSON brut du module. Cette migration le remplace par une instance de [Monaco Editor](https://microsoft.github.io/monaco-editor/) (l'éditeur qui équipe VS Code), apportant la coloration syntaxique, la validation JSON native et l'auto-complétion.

## 🌷 Remarques

- L'autocomplétion de champs dans le JSON ne fonctionne pas actuellement. Certains ont la liste de toutes les chaînes de caractères affichées dans le JSON comme suggestion, d'autres ont juste un `$schema`...
- Il faudrait vérifier l'utilité du code self.MonacoEnvironment qui ajoute un worker. 

### Note sur les workers

Monaco Editor nécessite des web workers pour la validation du langage. `vite-plugin-monaco-editor` (approche courante) s'est révélé incompatible avec Vite 8 qui utilise Rolldown à la place d'esbuild. Les workers sont donc configurés directement dans `index.js` via la syntaxe `?worker` native de Vite :

```js
import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
import jsonWorker from 'monaco-editor/esm/vs/language/json/json.worker?worker';

self.MonacoEnvironment = {
  getWorker(_, label) {
    if (label === 'json') return new jsonWorker();
    return new editorWorker();
  },
};
```

### Fichiers modifiés

#### `index.html`

Le `<textarea>` est remplacé par un `<div>`. Monaco crée son propre arbre DOM à l'intérieur du conteneur.

```diff
- <textarea
-   id="json_output"
-   class="modulix-editor-render__input"
- ></textarea>
+ <div
+   id="json_output"
+   class="modulix-editor-render__input"
+ ></div>
```

#### `index.js`

**Import ajouté :**

**Validation du schéma et création du modèle :**

`setDiagnosticsOptions` doit être appelé **avant** `createModel`. Quand le modèle est créé avec le langage `json`, Monaco déclenche `onLanguage("json")` qui instancie le `WorkerManager` — si le schéma est enregistré avant, le worker démarre déjà configuré.

```js
// Le fileMatch utilise un pattern glob simple : la lib préfixe automatiquement '**/'
// ce qui donne '**\/module.json' et matche l'URI 'inmemory://modulix/module.json'.
// Utiliser l'URI complète dans fileMatch perturbe le moteur de glob à cause du '://'.
jsonDefaults.setDiagnosticsOptions({
  validate: true,
  schemas: [{ uri: 'inmemory://modulix/module-schema.json', fileMatch: ['module.json'], schema }],
  schemaValidation: 'error',
});

// Le modèle est créé avec une URI qui correspond au fileMatch ci-dessus.
// Il est ensuite passé directement à l'éditeur (à la place de l'option `language: 'json'`).
const model = monaco.editor.createModel(
  '',
  'json',
  monaco.Uri.parse('inmemory://modulix/module.json'),
);
```

**Création de l'instance :**

```js
const monacoEditor = monaco.editor.create(jsonOutputContainer, {
  model,  // modèle avec URI → le schéma enregistré s'applique automatiquement
  theme: 'vs',
  automaticLayout: true,
  minimap: { enabled: false },
  scrollBeyondLastLine: false,
  fontSize: 13,
  fontFamily: "'SF Mono', 'Fira Code', 'Consolas', monospace",
  wordWrap: 'wordWrapColumn', // retour à la ligne automatique à la colonne fixée
  wordWrapColumn: 60,         // limite à 60 caractères par ligne
  unicodeHighlight: {         // autorise les caractères spéciaux sans surlignage d'avertissement
    ambiguousCharacters: false,  // guillemets typographiques («, »), apostrophe courbe ('), etc.
    invisibleCharacters: false,  // espaces insécables (\u00a0) et autres caractères invisibles
    nonBasicASCII: false,        // accents, emojis et tout caractère Unicode hors ASCII de base
  },
});
```

**API remplacées :**

| Avant (textarea)                        | Après (Monaco)                          |
|-----------------------------------------|-----------------------------------------|
| `jsonOutput.value`                      | `monacoEditor.getValue()`               |
| `jsonOutput.value = x`                  | `monacoEditor.setValue(x)`              |
| `jsonOutput.addEventListener('focusout', fn)` | `monacoEditor.onDidBlurEditorText(fn)` |

**Suppression de `displayJsonOutputError` :** Monaco valide le JSON nativement et souligne les erreurs directement dans l'éditeur — la gestion manuelle de l'état d'erreur via une classe CSS n'est plus nécessaire.

#### `styles.css`

`.modulix-editor-render__input` simplifié : les propriétés typographiques et de mise en forme (font-family, font-size, padding, color, background, resize) sont retirées car Monaco les gère en interne. Seules les propriétés de mise en page du conteneur sont conservées.

```diff
 .modulix-editor-render__input {
   height: calc(100% - 37px);
   width: 100%;
   border: 1px solid var(--border);
   border-radius: 0 0 6px 6px;
-  font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace;
-  font-size: 13px;
-  padding: 8px;
-  color: var(--text);
-  background: var(--surface);
-  resize: none;
+  overflow: hidden;
 }
-
-.modulix-editor-render__input--has-error {
-  border-color: var(--error);
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(229, 62, 62, 0.15);
-}
```

## 🐝 Pour tester
- Lancer modulix editor en local
- Prendre le JSON d'un module (ex : `bac-a-sable`) et le coller dans l'éditeur.
- Vérifier que cela fonctionne bien et que la partie JSON editor se met bien à jour.
- Tester la validation du schéma en changeant la valeur d'un champ (ex: duration en booléen).    
- Constater qu'une erreur apparaît bien sur le type 
- Vérifier que le bouton copier / nettoyer fonctionne toujours 🚀 