### PR TITLE
[BUGFIX] Chargement page principale KO à cause d'une erreur Jodit

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/jodit@4.2.27/es2015/jodit.min.css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/jodit/4.2.27/es2015/jodit.min.css"
       crossorigin="anonymous"
       referrerpolicy="no-referrer"
     />
@@ -91,6 +91,14 @@
         <span class="fa fa-trash me-1"></span> Supprimer
       </button>
     </header>
+    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@2.15.2/dist/jsoneditor.min.js"></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
+      crossorigin="anonymous"
+    ></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jodit/4.2.27/es2015/jodit.min.js"></script>
+    <script type="module" src="index.js"></script>
 
     <main class="modulix-editor">
       <div class="modulix-editor__editor">
@@ -111,14 +119,5 @@
         <div id="json_output" class="modulix-editor-render__input"></div>
       </div>
     </main>
-
-    <script src="https://cdn.jsdelivr.net/npm/@json-editor/json-editor@2.15.2/dist/jsoneditor.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/jodit@4.2.27/es2018/jodit.min.js"></script>
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
-      crossorigin="anonymous"
-    ></script>
-    <script type="module" src="index.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## 🪧 Problème

La page ne se charge plus entièrement à l'ouverture de [Modulix Editor](https://1024pix.github.io/modulix-editor/).
De plus, on trouve dans la console cette erreur : 
<img width="545" height="81" alt="image" src="https://github.com/user-attachments/assets/6b9cef9d-6288-4f90-97f9-77ff40e3ab37" />

Et dans la partie "Réseau", on constate qu'on a un retour 503 en faisant l'appel vers le CDN.

## 🌈 Proposition

Dans le fichier html principal, mettre à jour les lignes `<link>` et `<script>` qui chargent Jodit, en utilisant un chemin qui fonctionne (utilisation de cloudflare désormais). La même version de Jodit est conservée.

## ✊ Remarques

J'en ai profité pour positionner les balises `<script>` au-dessus du` <main>` dans la partie `<body>`

## 🎉 Pour tester

- Récupérer la branche localement
- Lancer modulix editor localement
- Ouvrir le site, qui doit s'afficher avec son formulaire.
- Vérifier les WYSIWYG doivent fonctionner normalement. => **j'ai un doute sur les balises `<p>`,` <br>` etc qu'on veut conserver ou non** 🤔

